### PR TITLE
Correct username in 5.7 SU test

### DIFF
--- a/section_5/cis_5.7/cis_5.7.yml
+++ b/section_5/cis_5.7/cis_5.7.yml
@@ -24,7 +24,7 @@ file:
     title: 5.7 | Ensure access to the su command is restricted | /etc/group
     exists: true
     contains:
-    - '/^{{ .Vars.amazon2cis_sugroup }}:x:10:vagrant,root$/'
+    - '/^{{ .Vars.amazon2cis_sugroup }}:x:10:ec2-user,root$/'
     meta:
       server: 1
       workstation: NA


### PR DESCRIPTION
Overall Review of Changes:
The correct username in Amazon Linux 2 is ec2-user - Cannot see any usage of a Vagrant user in either the hardening repo or audit repo.

How has this been tested?:
We have run it against a EC2 instance that has had the Amazon2-CIS repo hardening steps completed.