### PR TITLE
Correct 3.5.1.6 test for Amazon Linux 2

### DIFF
--- a/section_3/cis_3.5/cis_3.5.1.x.yml
+++ b/section_3/cis_3.5/cis_3.5.1.x.yml
@@ -131,7 +131,7 @@ command:
   {{ if .Vars.amazon2cis_rule_3_5_1_6 }}
   nic_assigned:
     title: 3.5.1.6 | Ensure network interfaces are assigned to appropriate zone
-    exec:  "nmcli -t connection show | awk -F ':' '{if($4){print $4}}' | while read INT; do firewall-cmd --get-active-zones | grep -B1 $INT; done"
+    exec:  "find /sys/class/net/* -maxdepth 1 | awk -F\"/\" '{print $NF}' | while read -r netint; do [ \"$netint\" != \"lo\" ] && echo \"$netint\"; done | while read -r netint; do firewall-cmd --get-active-zones | grep -B1 $netint; done"
     exit-status: 0
     {{ range .Vars.amazon2cis_firewall_interface }}
     stdout: {{ . }}

--- a/section_4/cis_4.1/cis_4.1.3.yml
+++ b/section_4/cis_4.1/cis_4.1.3.yml
@@ -25,9 +25,9 @@ command:
     exec: auditctl -l | grep time-change
     exit-status: 0
     stdout:
-    - '-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change'
+    - '-a always,exit -F arch=b32 -S stime,settimeofday,adjtimex -F key=time-change'
     - '-a always,exit -F arch=b32 -S clock_settime -F key=time-change'
-    - '-a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change'
+    - '-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=time-change'
     - '-a always,exit -F arch=b64 -S clock_settime -F key=time-change'
     - '-w /etc/localtime -p wa -k time-change'
     meta:

--- a/vars/CIS.yml
+++ b/vars/CIS.yml
@@ -373,8 +373,7 @@ amazon2cis_ip6tables_boot_config: /etc/sysconfig/ip6tables
 
 amazon2cis_default_firewall_zone: 'public'
 amazon2cis_firewall_interface:
-  - ['ens224']
-  - ['ens192']
+  - ['eth0']
 
 
 ### Section 4


### PR DESCRIPTION
**Overall Review of Changes:**
Correct the test for 3.5.1.6 so that it runs correctly on Amazon Linux 2.

`nmcli` is unavailable on Amazon Linux 2
The CIS Benchmark document provides an alternative command for the test, which is what I have changed it to.
However I had to adjust the command slightly as the `[ "$netint" != "lo" ]` part to filter out the `lo` interface would mean that the test would always have an exit code of 1. So I have doubled up the loop to drop out the `lo` interface first and then iterate over the remaining interfaces.

Secondly, I have changed the default `amazon2cis_firewall_interface` to be `eth0`. I know this can be overridden by providing our own variables, but `eth0` is the default on Amazon Linux 2, so it makes sense to not have to override this unless network interfaces have been modified.

**How has this been tested?:**
Tested against an Amazon Linux 2 EC2 instance that had the AMAZON2-CIS playbook run against it.

