### PR TITLE
3.1.1 Allow specifying which method was used to disable IPv6

### DIFF
--- a/section_3/cis_3.1/cis_3.1.1.yml
+++ b/section_3/cis_3.1/cis_3.1.1.yml
@@ -1,6 +1,7 @@
 {{ if .Vars.amazon2cis_level2 }}
 {{ if not .Vars.amazon2cis_ipv6_required }}
   {{ if .Vars.amazon2cis_rule_3_1_1 }}
+    {{ if eq .Vars.amazon2cis_ipv6_disabled_by "grub" }}
 command:
   ipv6_grub:
     title: 3.1.1 | disable IPv6 | grub
@@ -17,6 +18,8 @@ command:
       CISv8_IG1: false
       CISv8_IG2: true
       CISv8_IG3: true
+    {{ end }}
+    {{ if eq .Vars.amazon2cis_ipv6_disabled_by "sysctl" }}
 kernel-param:
   net.ipv6.conf.all.disable_ipv6:
     title: 3.1.1 | disable IPv6 | kernel
@@ -43,6 +46,8 @@ kernel-param:
       CISv8_IG1: false
       CISv8_IG2: true
       CISv8_IG3: true
+    {{ end }}
+    {{ if eq .Vars.amazon2cis_ipv6_disabled_by "grub" }}
 file:
   /etc/default/grub:
     title: 3.1.1 | Disable IPv6 | default_grub
@@ -59,6 +64,7 @@ file:
       CISv8_IG1: false
       CISv8_IG2: true
       CISv8_IG3: true
+    {{ end }}
   {{ end }}
 {{ end }}
 {{ end }}

--- a/vars/CIS.yml
+++ b/vars/CIS.yml
@@ -331,6 +331,8 @@ amazon2cis_gui: false
 
 # IPv6 required
 amazon2cis_ipv6_required: false
+# Method used to disable IPv6, either grub or sysctl
+amazon2cis_ipv6_disabled_by: sysctl 
 
 # System network parameters (host only OR host and router)
 amazon2cis_is_router: false


### PR DESCRIPTION
In the CIS Amazon Linux 2 benchmark, for "3.1.1 Disable IPv6" it states:

> Use **one** of the two following methods to disable IPv6 on the system

Then goes on to describe disabling IPv6 either via grub settings or via sysctl settings.

In the AMAZON2-CIS repo, the sysctl method is used to disable IPv6. However, the audit tests in this repo test for *both* methods.

As it could still be acceptable to disable IPv6 via grub, rather than deleting the grub tests, this change introduces a new variable `amazon2cis_ipv6_disabled_by` which should be set to either `grub` or `sysctl`.

Then depending on which value is set it will only run the appropriate tests.

I've defaulted it to `sysctl` to match the AMAZON2-CIS repo behaviour.